### PR TITLE
Use mamba to solve and create the environment instead of conda

### DIFF
--- a/run-pack-and-test.sh
+++ b/run-pack-and-test.sh
@@ -7,7 +7,7 @@ set -e
 source /root/.bashrc 
 
 # create an dpack environment
-conda env create -f $ENVIRONMENT_FILE
+mamba env create -f $ENVIRONMENT_FILE
 conda pack -n $ENVIRONMENT_NAME --ignore-missing-files --output $HOME/$ENVIRONMENT_NAME.tar.gz
 
 # unpack 


### PR DESCRIPTION
Just wanted to see if you might want to change this to use mamba instead of conda for creating the environment? Currently the nightly updating build for the python 3.8 environment is failing, and it appears to be because it is using more memory than is available to an action.

I have a sample working run here using mamba that also solves significantly faster: https://github.com/jbellister-slac/lcls-python3.8-env/runs/7619114968

I compared the solve to the conda version and it looks good to me. And the packed up environment seems to work fine. But no problem if it's better to stay with conda here, I can just point the 3.8 environment to use a fork instead. Or maybe there is another issue I am overlooking.